### PR TITLE
fix sina stock lost bug

### DIFF
--- a/easyquotation/sina.py
+++ b/easyquotation/sina.py
@@ -17,6 +17,9 @@ class Sina(basequotation.BaseQuotation):
         r"(\w{2}\d+)=[^\s]([^\s,]+?)%s%s"
         % (r",([\.\d]+)" * 29, r",([-\.\d:]+)" * 2)
     )
+    del_null_data_stock = re.compile(
+        r"(\w{2}\d+)=\"\";"
+    )
 
     @property
     def stock_api(self) -> str:
@@ -25,6 +28,7 @@ class Sina(basequotation.BaseQuotation):
 
     def format_response_data(self, rep_data, prefix=False):
         stocks_detail = "".join(rep_data)
+        stocks_detail = self.del_null_data_stock.sub('', stocks_detail)
         grep_str = self.grep_detail_with_prefix if prefix else self.grep_detail
         result = grep_str.finditer(stocks_detail)
         stock_dict = dict()


### PR DESCRIPTION
the sina interface get data like this:
> var hq_str_sz000001="平安银行,15.090,14.940,14.900,15.140,14.780,14.900,14.910,98690293,1474900257.600,450764,14.900,91200,14.890,49968,14.880,128145,14.870,165000,14.860,59600,14.910,86054,14.920,177698,14.930,136934,14.940,90195,14.950,2019-08-16,15:00:03,00";
> var hq_str_sz000002="万 科Ａ,26.400,26.340,26.280,26.520,26.160,26.270,26.280,35817484,944690704.280,56453,26.270,109040,26.260,153700,26.250,22700,26.240,92200,26.230,197276,26.280,39800,26.290,3200,26.300,20806,26.310,16744,26.320,2019-08-16,15:00:03,00";
> var hq_str_sz000003="";
> var hq_str_sz000004="国农科技,18.900,19.090,19.150,19.420,18.880,19.140,19.150,750446,14396705.560,3600,19.140,18000,19.130,1600,19.120,100,19.110,13500,19.100,3700,19.150,4000,19.180,1500,19.200,400,19.220,1600,19.250,2019-08-16,15:00:03,00";

the hq_str_sz000003 data is null,and the regex pattern **grep_detail_with_prefix**  will match the sz000003 to sz000004's end,the sz000004's data is attach to sz000003. the sz000004 data is "lost",and the sz000003 data is wrong.  
So remove the stock null data like this:var hq_str_sz000003=""; for fix the grep_detail_with_prefix bug.